### PR TITLE
completed the adminAuth middleware add added .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+JWT_SECRET=`jwt secret`
+JWT_EXPIRE=`time to expire jwt`
+MONGO_DB=`url for db`
+DB_MODE=`local if local mongodb instance needed`
+OWNER_USERNAME=`owner username`
+OWNER_PASSWORD=`owner password`

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -1,0 +1,15 @@
+exports.OwnerLogin = async (req, res, next) => {
+   try {
+      throw Error('Route Not Implemented')
+   } catch (error) {
+      next(error)
+   }
+}
+
+exports.register = async (req, res, next) => {
+   try {
+      throw Error('Route Not Implemented')
+   } catch (error) {
+      next(error)
+   }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 const express = require('express')
 const compression = require('compression')
-const cors = require('cors')
 const cookieParser = require('cookie-parser')
 const session = require('express-session')
 const path = require('path')

--- a/src/middlewares/adminAuth.js
+++ b/src/middlewares/adminAuth.js
@@ -1,0 +1,44 @@
+const Admin = require('../models/admin')
+const jwt = require('jsonwebtoken')
+
+module.exports = (allowedRoles) => {
+    return async (req, res, next) => {
+        try {
+            if(allowedRoles instanceof String) {
+                allowedRoles = [allowedRoles]
+            }
+            // Get the data from the authorization cookies
+            const token = req.cookies.authorization
+            const userInfo = await jwt.verify(token, process.env.JWT_SECRET)
+            // if the allowedRoles contains owner and current user is owner, call next()
+            if(allowedRoles.includes("owner") && 
+               userInfo.username === process.env.OWNER_USERNAME && 
+               userInfo.password === process.env.OWNER_PASSWORD
+            )  {
+                next()
+            } else {
+                // For another admin get the document from db and verify for each allowed role 
+                const admin = await Admin.findById(userInfo._id)
+                if(!admin) {
+                    throw new Error('Admin Not Found')
+                }
+                for(role in allowedRoles) {
+                    if(admin.role === role) {
+                        req.adminInfo = {
+                            token: token,
+                            admin: admin,
+                        }
+                        next();
+                        break;
+                    }
+                }
+            }
+        } catch (err) {
+            res.status(401).json({
+                error: true,
+                message: 'Login First',
+            })
+        }
+    }
+}
+

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -1,0 +1,16 @@
+/** Write User routes here */
+const router = require('express').Router()
+const adminController = require('../controllers/admin')
+
+router.post('/owner/login', adminController.OwnerLogin)
+router.post('/register', adminController.register)
+
+router.get('/login',(req,res)=>{
+    
+})
+router.get('/register',(req,res)=>{
+
+})
+
+
+module.exports = router

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,8 +2,10 @@ const express = require('express')
 const router = express.Router()
 const Auth = require('../middlewares/auth')
 const userRouter = require('./user')
+const adminRouter = require('./admin')
 
 router.use('/user', userRouter)
+router.use('/admin', adminRouter)
 
 router.get('/', (req, res) => {
     res.render('index')


### PR DESCRIPTION
# Usage of admin auth middleware
- the adminAuth function returns a middleware and is configurable according to the roles u need, u can use it as
`adminAuth(['owner'])` or `admin('owner')` for allowing a single role 
- for multiple roles, use it as `adminAuth(['owner', 'mod'])`

**EXAMPLE**
```
router.get('/protected-route', adminAuth(['owner', 'mod']), Controller.routefunction )
```